### PR TITLE
Update VendrSyncHandlerBase to reflect changes in latest uSync API

### DIFF
--- a/src/Vendr.uSync/Handlers/VendrSyncHandlerBase.cs
+++ b/src/Vendr.uSync/Handlers/VendrSyncHandlerBase.cs
@@ -67,11 +67,14 @@ namespace Vendr.uSync.Handlers
 
             foreach (var action in actions)
             {
-                var result = Import(action.FileName, config, SerializerFlags.None);
-                if (result.Success)
+                var results = Import(action.FileName, config, SerializerFlags.None);
+                foreach (var result in results)
                 {
-                    var attempt = ImportSecondPass(action.FileName, result.Item, config, null);
-                    // postActions.Add();
+                    if (result.Success)
+                    {
+                        var attempt = ImportSecondPass(result, config, null);
+                        // postActions.Add();
+                    }
                 }
             }
 

--- a/src/Vendr.uSync/Serializers/CountrySerializer.cs
+++ b/src/Vendr.uSync/Serializers/CountrySerializer.cs
@@ -63,17 +63,17 @@ namespace Vendr.uSync.Serializers
                 country.SetSortOrder(sortOrder);
 
                 var defaultCurrencyId = node.Element(nameof(country.DefaultCurrencyId)).ValueOrDefault(country.DefaultCurrencyId);
-                if (_vendrApi.GetCurrency(defaultCurrencyId.Value) != null) {
+                if (defaultCurrencyId.HasValue && _vendrApi.GetCurrency(defaultCurrencyId.Value) != null) {
                     country.SetDefaultCurrency(defaultCurrencyId);
                 }
 
                 var defaultPaymentId = node.Element(nameof(country.DefaultPaymentMethodId)).ValueOrDefault(country.DefaultPaymentMethodId);
-                if (_vendrApi.GetPaymentMethod(defaultPaymentId.Value) != null) {
+                if (defaultPaymentId.HasValue && _vendrApi.GetPaymentMethod(defaultPaymentId.Value) != null) {
                     country.SetDefaultPaymentMethod(defaultPaymentId);
                 }
 
                 var defaultShippingId = node.Element(nameof(country.DefaultShippingMethodId)).ValueOrDefault(country.DefaultShippingMethodId);
-                if (_vendrApi.GetShippingMethod(defaultShippingId.Value) != null) {
+                if (defaultShippingId.HasValue && _vendrApi.GetShippingMethod(defaultShippingId.Value) != null) {
                     country.SetDefaultShippingMethod(defaultShippingId);
                 }
 

--- a/src/Vendr.uSync/Vendr.uSync.csproj
+++ b/src/Vendr.uSync/Vendr.uSync.csproj
@@ -149,11 +149,11 @@
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
-    <Reference Include="uSync8.BackOffice, Version=8.6.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\uSync.BackOffice.Core.8.6.5\lib\net472\uSync8.BackOffice.dll</HintPath>
+    <Reference Include="uSync8.BackOffice, Version=8.8.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\uSync.BackOffice.Core.8.8.4\lib\net472\uSync8.BackOffice.dll</HintPath>
     </Reference>
-    <Reference Include="uSync8.Core, Version=8.6.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\uSync.Core.8.6.5\lib\net472\uSync8.Core.dll</HintPath>
+    <Reference Include="uSync8.Core, Version=8.8.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\uSync.Core.8.8.4\lib\net472\uSync8.Core.dll</HintPath>
     </Reference>
     <Reference Include="Vendr.Core, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Vendr.Core.1.3.0\lib\net472\Vendr.Core.dll</HintPath>

--- a/src/Vendr.uSync/packages.config
+++ b/src/Vendr.uSync/packages.config
@@ -31,7 +31,7 @@
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
   <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
-  <package id="uSync.BackOffice.Core" version="8.6.5" targetFramework="net472" />
-  <package id="uSync.Core" version="8.6.5" targetFramework="net472" />
+  <package id="uSync.BackOffice.Core" version="8.8.4" targetFramework="net472" />
+  <package id="uSync.Core" version="8.8.4" targetFramework="net472" />
   <package id="Vendr.Core" version="1.3.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Fixes compilation with latest uSync and Umbraco packages
Also fixes a NullReference exception when importing countries with no values set in the currency, payment, and/or shipping fields