### PR TITLE
Add EntiyTypes - so item manager can be used.

### DIFF
--- a/src/Vendr.uSync/Config/uSync8.config
+++ b/src/Vendr.uSync/Config/uSync8.config
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<uSync>
+  <BackOffice>
+    <Folder>~/uSync/v8/</Folder>
+    <FlatFolders>True</FlatFolders>
+    <ImportAtStartup>False</ImportAtStartup>
+    <ExportAtStartup>False</ExportAtStartup>
+    <ExportOnSave>True</ExportOnSave>
+    <UseGuidFilenames>False</UseGuidFilenames>
+    <BatchSave>False</BatchSave>
+    <!-- calls a rebuild cache when an import completes
+        (for Umbraco 8.3+ recommended value is false)  -->
+    <RebuildCacheOnCompletion>False</RebuildCacheOnCompletion>
+    <!-- handler sets -->
+    <HandlerSets Default="default">
+      <Handlers Name="default">
+        <Handler Alias="dataTypeHandler" Enabled="true" />
+        <Handler Alias="languageHandler" Enabled="true" />
+        <Handler Alias="macroHandler" Enabled="true" />
+        <Handler Alias="mediaTypeHandler" Enabled="true" />
+        <Handler Alias="memberTypeHandler" Enabled="false" />
+        <Handler Alias="templateHandler" Enabled="true" />
+        <Handler Alias="contentTypeHandler" Enabled="true" />
+        <Handler Alias="contentHandler" Enabled="true" />
+        <Handler Alias="contentTemplateHandler" Enabled="true" />
+        <Handler Alias="dictionaryHandler" Enabled="true" />
+        <Handler Alias="domainHandler" Enabled="true" />
+        <Handler Alias="mediaHandler" Enabled="true" />
+        <Handler Alias="relationTypeHandler" Enabled="false" />
+      </Handlers>
+    </HandlerSets>
+    <!-- custom mappings to things that are already in umbraco -->
+    <!-- if you content is stored exactly like it is in an existing 
+		     propertyEditor, you can map to it here. -->
+    <!-- 
+		<Mappings>
+			<Add Key="MyCustomUrlPicker" Value="Umbraco.MultiUrlPicker" />
+		</Mappings>
+		-->
+    <!-- defaults settings that can be used across all handlers -->
+    <!-- 
+		<HandlerDefaults>
+			<Add Key="NoRemove" Value="true" />
+			<Add Key="CreateOnly" Value="true" />
+		</HandlerDefaults>
+		-->
+  </BackOffice>
+</uSync>

--- a/src/Vendr.uSync/Dependencies/VendrOrderStatusDependecyChecker.cs
+++ b/src/Vendr.uSync/Dependencies/VendrOrderStatusDependecyChecker.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+using uSync8.Core.Dependency;
+
+using Vendr.Core.Models;
+
+namespace Vendr.uSync.Dependencies
+{
+    public class VendrOrderStatusDependecyChecker : ISyncDependencyChecker<OrderStatusReadOnly>
+    {
+        public UmbracoObjectTypes ObjectType => UmbracoObjectTypes.Unknown;
+
+        public IEnumerable<uSyncDependency> GetDependencies(OrderStatusReadOnly item, DependencyFlags flags)
+        {
+            return new uSyncDependency
+            {
+                Name = item.Name,
+                Order = VendrConstants.Priorites.OrderStatus,
+                Udi = Udi.Create(VendrConstants.UdiEntityType.OrderStatus, item.Id)
+            }.AsEnumerableOfOne();
+        }
+    }
+}

--- a/src/Vendr.uSync/Dependencies/VendrStoreDependencyChecker.cs
+++ b/src/Vendr.uSync/Dependencies/VendrStoreDependencyChecker.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+using uSync8.Core.Dependency;
+
+using Vendr.Core.Api;
+using Vendr.Core.Models;
+
+namespace Vendr.uSync.Dependencies
+{
+    public class VendrStoreDependencyChecker : ISyncDependencyChecker<StoreReadOnly>
+    {
+        private readonly IVendrApi _vendrApi;
+
+        public VendrStoreDependencyChecker(IVendrApi vendrApi)
+        {
+            _vendrApi = vendrApi;
+        }
+
+        public UmbracoObjectTypes ObjectType => UmbracoObjectTypes.Unknown;
+
+        public IEnumerable<uSyncDependency> GetDependencies(StoreReadOnly item, DependencyFlags flags)
+        {
+            if (item == null) return Enumerable.Empty<uSyncDependency>();
+
+            var items = new List<uSyncDependency>();
+
+
+            items.Add(new uSyncDependency
+            {
+                Name = item.Name,
+                Order = VendrConstants.Priorites.Stores,
+                Udi = Udi.Create(VendrConstants.UdiEntityType.Store, item.Id),
+                Flags = DependencyFlags.None
+            });
+
+            // a store has a lot of dependencies,
+            items.AddRange(GetOrderStatuses(item.Id));
+            items.AddRange(GetCurrencies(item.Id));
+            items.AddRange(GetShippingMethods(item.Id));
+            items.AddRange(GetCountries(item.Id));
+            items.AddRange(GetRegions(item.Id));
+            items.AddRange(GetPaymentMethods(item.Id));
+            items.AddRange(GetTaxClasses(item.Id));
+            items.AddRange(GetEmailTemplates(item.Id));
+            items.AddRange(GetExportTemplates(item.Id));
+            items.AddRange(GetPrintTemplates(item.Id));
+
+            return items;
+        }
+
+        public IEnumerable<uSyncDependency> GetOrderStatuses(Guid storeId)
+            => _vendrApi.GetOrderStatuses(storeId)
+                    .Select(x => new uSyncDependency
+                    {
+                        Name = x.Name,
+                        Order = VendrConstants.Priorites.OrderStatus,
+                        Udi = Udi.Create(VendrConstants.UdiEntityType.OrderStatus, x.Id)
+                    });
+
+        private IEnumerable<uSyncDependency> GetCurrencies(Guid storeId)
+            => _vendrApi.GetCurrencies(storeId)
+                    .Select(x => new uSyncDependency
+                    {
+                        Name = x.Name,
+                        Order = VendrConstants.Priorites.Currency,
+                        Udi = Udi.Create(VendrConstants.UdiEntityType.Currency, x.Id)
+                    });
+
+        private IEnumerable<uSyncDependency> GetShippingMethods(Guid storeId)
+            => _vendrApi.GetShippingMethods(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.ShippingMethod,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.ShippingMethod)
+                });
+
+        private IEnumerable<uSyncDependency> GetCountries(Guid storeId)
+            => _vendrApi.GetCountries(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.Country,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.Country, x.Id)
+                });
+
+        private IEnumerable<uSyncDependency> GetRegions(Guid storeId)
+            => _vendrApi.GetRegions(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.Region,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.Region, x.Id)
+                });
+
+
+        private IEnumerable<uSyncDependency> GetPaymentMethods(Guid storeId)
+            => _vendrApi.GetPaymentMethods(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.PaymentMethod,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.PaymentMethod, x.Id)
+                });
+
+        private IEnumerable<uSyncDependency> GetTaxClasses(Guid storeId)
+            => _vendrApi.GetTaxClasses(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.TaxClass,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.TaxClass, x.Id)
+                });
+
+        private IEnumerable<uSyncDependency> GetEmailTemplates(Guid storeId)
+            => _vendrApi.GetEmailTemplates(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.EmailTemplate,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.EmailTemplate, x.Id)
+                });
+
+        private IEnumerable<uSyncDependency> GetExportTemplates(Guid storeId)
+            => _vendrApi.GetExportTemplates(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.EmailTemplate,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.EmailTemplate, x.Id)
+                });
+
+        private IEnumerable<uSyncDependency> GetPrintTemplates(Guid storeId)
+            => _vendrApi.GetPrintTemplates(storeId)
+                .Select(x => new uSyncDependency
+                {
+                    Name = x.Name,
+                    Order = VendrConstants.Priorites.PrintTemplate,
+                    Udi = Udi.Create(VendrConstants.UdiEntityType.PrintTemplate, x.Id)
+                });
+                
+
+
+    }
+}

--- a/src/Vendr.uSync/Handlers/CountryHandler.cs
+++ b/src/Vendr.uSync/Handlers/CountryHandler.cs
@@ -24,7 +24,7 @@ namespace Vendr.uSync.Handlers
     ///  which have to run after country as they depend on them.
     /// </remarks>
     [SyncHandler("vendrCountryHandler", "Countries", "Vendr\\Country", VendrConstants.Priorites.Country,
-        Icon = "icon-globe", IsTwoPass = true)]
+        Icon = "icon-globe", IsTwoPass = true, EntityType = VendrConstants.UdiEntityType.Country)]
     public class CountryHandler : VendrSyncHandlerBase<CountryReadOnly>, ISyncPostImportHandler, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/CurrencyHandler.cs
+++ b/src/Vendr.uSync/Handlers/CurrencyHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrCurrencyHandler", "Currencies", "Vendr\\Currency", VendrConstants.Priorites.Currency,
-        Icon = "icon-coins-dollar-alt")]
+        Icon = "icon-coins-dollar-alt", EntityType = VendrConstants.UdiEntityType.Currency)]
     public class CurrencyHandler : VendrSyncHandlerBase<CurrencyReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/EmailTemplateHandler.cs
+++ b/src/Vendr.uSync/Handlers/EmailTemplateHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrEmailTemplateHandler", "Email Templates", "Vendr\\EmailTemplate", VendrConstants.Priorites.EmailTemplate,
-        Icon = "icon-mailbox")]
+        Icon = "icon-mailbox", EntityType = VendrConstants.UdiEntityType.EmailTemplate)]
     public class EmailTemplateHandler : VendrSyncHandlerBase<EmailTemplateReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/ExportTemplateHandler.cs
+++ b/src/Vendr.uSync/Handlers/ExportTemplateHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrExportTemplateHandler", "Export Templates", "Vendr\\ExportTemplate", VendrConstants.Priorites.ExportTemplate,
-        Icon = "icon-sharing-iphone")]
+        Icon = "icon-sharing-iphone", EntityType = VendrConstants.UdiEntityType.ExportTemplate)]
     public class ExportTemplateHandler : VendrSyncHandlerBase<ExportTemplateReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/OrderStatusHandler.cs
+++ b/src/Vendr.uSync/Handlers/OrderStatusHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrOrderStatusHandler", "Order Statuses", "Vendr\\OrderStatus", VendrConstants.Priorites.OrderStatus,
-        Icon = "icon-file-cabinet")]
+        Icon = "icon-file-cabinet", EntityType = VendrConstants.UdiEntityType.OrderStatus)]
     public class OrderStatusHandler : VendrSyncHandlerBase<OrderStatusReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/PaymentMethodHandler.cs
+++ b/src/Vendr.uSync/Handlers/PaymentMethodHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrPaymentMethodHandler", "Payment Methods", "Vendr\\PaymentMethod", VendrConstants.Priorites.PaymentMethod,
-        Icon = "icon-multiple-credit-cards")]
+        Icon = "icon-multiple-credit-cards", EntityType = VendrConstants.UdiEntityType.PaymentMethod)]
     public class PaymentMethodHandler : VendrSyncHandlerBase<PaymentMethodReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/PrintTemplateHandler.cs
+++ b/src/Vendr.uSync/Handlers/PrintTemplateHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrPrintTemplateHandler", "Print Templates", "Vendr\\PrintTemplate", VendrConstants.Priorites.PrintTemplate,
-        Icon = "icon-print")]
+        Icon = "icon-print", EntityType = VendrConstants.UdiEntityType.PrintTemplate)]
     public class PrintTemplateHandler : VendrSyncHandlerBase<PrintTemplateReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/RegionHandler.cs
+++ b/src/Vendr.uSync/Handlers/RegionHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrRegionHandler", "Regions", "Vendr\\Region", VendrConstants.Priorites.Region,
-        Icon = "icon-flag-alt", IsTwoPass = true)]
+        Icon = "icon-flag-alt", IsTwoPass = true, EntityType = VendrConstants.UdiEntityType.Region)]
     public class RegionHandler : VendrSyncHandlerBase<RegionReadOnly>, ISyncExtendedHandler, ISyncPostImportHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/ShippingMethodHandler.cs
+++ b/src/Vendr.uSync/Handlers/ShippingMethodHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrShippingMethodHandler", "Shipping Methods", "Vendr\\ShippingMethod", VendrConstants.Priorites.ShippingMethod,
-        Icon = "icon-truck")]
+        Icon = "icon-truck", EntityType = VendrConstants.UdiEntityType.ShippingMethod)]
     public class ShippingMethodHandler : VendrSyncHandlerBase<ShippingMethodReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Handlers/StoreHandler.cs
+++ b/src/Vendr.uSync/Handlers/StoreHandler.cs
@@ -18,7 +18,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrStoreHandler", "Stores", "Vendr\\Stores", VendrConstants.Priorites.Stores,
-        Icon = "icon-store", IsTwoPass = true)]
+        Icon = "icon-store", IsTwoPass = true, EntityType = VendrConstants.UdiEntityType.Store)]
     public class StoreHandler : VendrSyncHandlerBase<StoreReadOnly>, ISyncExtendedHandler, ISyncPostImportHandler
     {
         // puts the handler into a 'vendr' group, so they can be synced seperatly from settings and content.

--- a/src/Vendr.uSync/Handlers/TaxClassHandler.cs
+++ b/src/Vendr.uSync/Handlers/TaxClassHandler.cs
@@ -17,7 +17,7 @@ using Vendr.Core.Models;
 namespace Vendr.uSync.Handlers
 {
     [SyncHandler("vendrTaxClassHandler", "Taxes", "Vendr\\TaxClass", VendrConstants.Priorites.TaxClass,
-        Icon = "icon-library")]
+        Icon = "icon-library", EntityType = VendrConstants.UdiEntityType.TaxClass)]
     public class TaxClassHandler : VendrSyncHandlerBase<TaxClassReadOnly>, ISyncExtendedHandler
     {
         public override string Group => VendrConstants.Group;

--- a/src/Vendr.uSync/Serializers/OrderStatusSerializer.cs
+++ b/src/Vendr.uSync/Serializers/OrderStatusSerializer.cs
@@ -16,7 +16,8 @@ using Vendr.uSync.Extensions;
 namespace Vendr.uSync.Serializers
 {
     [SyncSerializer("FA15B3E1-8100-431E-BC95-4B74134A42DD", "OrderStatus Serializer", VendrConstants.Serialization.OrderStatus)]
-    public class OrderStatusSerializer : VendrSerializerBase<OrderStatusReadOnly>, ISyncSerializer<OrderStatusReadOnly>
+    public class OrderStatusSerializer : VendrSerializerBase<OrderStatusReadOnly>, ISyncSerializer<OrderStatusReadOnly>,
+        ISyncNodeSerializer<OrderStatusReadOnly>
     {
         public OrderStatusSerializer(IVendrApi vendrApi, IUnitOfWorkProvider uowProvider, ILogger logger)
             : base(vendrApi, uowProvider, logger)
@@ -66,7 +67,6 @@ namespace Vendr.uSync.Serializers
                 item.SetSortOrder(node.Element(nameof(item.SortOrder)).ValueOrDefault(item.SortOrder));
 
                 _vendrApi.SaveOrderStatus(item);
-
                 uow.Complete();
 
                 return SyncAttempt<OrderStatusReadOnly>.Succeed(name, item.AsReadOnly(), ChangeType.Import);

--- a/src/Vendr.uSync/ServiceConnectors/StoreServiceConnector.cs
+++ b/src/Vendr.uSync/ServiceConnectors/StoreServiceConnector.cs
@@ -1,0 +1,45 @@
+﻿
+using Umbraco.Core;
+
+namespace Vendr.uSync.ServiceConnectors
+{
+    /// <summary>
+    ///  Define what a store UDI looks like
+    /// </summary>
+    [UdiDefinition(VendrConstants.UdiEntityType.Store, UdiType.GuidUdi)]
+    public class StoreServiceConnector : VendrBaseServiceConnector { }
+
+    /// <summary>
+    ///  Define what a OrderStatus UDI looks like
+    /// </summary>
+    [UdiDefinition(VendrConstants.UdiEntityType.OrderStatus, UdiType.GuidUdi)]
+    public class OrderStatusServiceConnector : VendrBaseServiceConnector { }
+
+    /// <summary>
+    ///  Define what a Shipping method UDI looks like
+    /// </summary>
+    [UdiDefinition(VendrConstants.UdiEntityType.ShippingMethod, UdiType.GuidUdi)]
+    public class ShippingMethodServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.Country, UdiType.GuidUdi)]
+    public class CountryServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.Currency, UdiType.GuidUdi)]
+    public class CurrencyServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.PaymentMethod, UdiType.GuidUdi)]
+    public class PaymentServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.TaxClass, UdiType.GuidUdi)]
+    public class TaxServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.EmailTemplate, UdiType.GuidUdi)]
+    public class EmailTemplateServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.ExportTemplate, UdiType.GuidUdi)]
+    public class ExportTemplateServiceConnector : VendrBaseServiceConnector { }
+
+    [UdiDefinition(VendrConstants.UdiEntityType.PrintTemplate, UdiType.GuidUdi)]
+    public class PrintTemplateServiceConnector : VendrBaseServiceConnector { }
+
+}

--- a/src/Vendr.uSync/ServiceConnectors/VendrBaseServiceConnector.cs
+++ b/src/Vendr.uSync/ServiceConnectors/VendrBaseServiceConnector.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+
+namespace Vendr.uSync.ServiceConnectors
+{
+    /// <summary>
+    ///  this class does nothing, but the only way to add custom Udi values to umbraco
+    ///  it to attach the attribute to a class implimenting IServiceConnector. 
+    ///  so for brevity we do that attached to something that impliments this base class.
+    /// </summary>
+    public abstract class VendrBaseServiceConnector : IServiceConnector
+    {
+        public bool Compare(IArtifact art1, IArtifact art2, ICollection<Difference> differences = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Explode(UdiRange range, List<Udi> udis)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IArtifact GetArtifact(Udi udi)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IArtifact GetArtifact(object entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public NamedUdiRange GetRange(Udi udi, string selector)
+        {
+            throw new NotImplementedException();
+        }
+
+        public NamedUdiRange GetRange(string entityType, string sid, string selector)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Process(ArtifactDeployState dart, IDeployContext context, int pass)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ArtifactDeployState ProcessInit(IArtifact art, IDeployContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Vendr.uSync/SyncManagers/OrderSyncManager.cs
+++ b/src/Vendr.uSync/SyncManagers/OrderSyncManager.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Umbraco.Core;
+
+using uSync8.Core.Sync;
+
+using Vendr.Core.Api;
+using Vendr.Core.Models;
+
+using static Vendr.Web.Constants.Trees.Settings;
+
+namespace Vendr.uSync.SyncManagers
+{
+    public class OrderSyncManager : ISyncItemManager
+    {
+        private readonly Dictionary<NodeType, string> _nodeToEntityMapping = new Dictionary<NodeType, string>
+        {
+            { NodeType.Store, VendrConstants.UdiEntityType.Store },
+            { NodeType.OrderStatuses, VendrConstants.UdiEntityType.OrderStatus },
+            { NodeType.ShippingMethods, VendrConstants.UdiEntityType.ShippingMethod },
+            { NodeType.Countries, VendrConstants.UdiEntityType.Country },
+            { NodeType.Currencies, VendrConstants.UdiEntityType.Currency },
+            { NodeType.PaymentMethods, VendrConstants.UdiEntityType.PaymentMethod },
+            { NodeType.TaxClasses, VendrConstants.UdiEntityType.TaxClass },
+            { NodeType.EmailTemplates, VendrConstants.UdiEntityType.EmailTemplate },
+            { NodeType.ExportTemplates, VendrConstants.UdiEntityType.ExportTemplate },
+            { NodeType.PrintTemplates, VendrConstants.UdiEntityType.PrintTemplate }
+        };
+
+        public string[] EntityTypes => _nodeToEntityMapping.Values.ToArray();
+
+        public string[] Trees => new string[] { Vendr.Web.Constants.Trees.Settings.Alias };
+
+        private readonly IVendrApi _vendrApi;
+
+        public OrderSyncManager(IVendrApi vendrApi)
+        {
+            _vendrApi = vendrApi;
+        }
+
+        /// <summary>
+        ///  return the local entity, based on what the user picked from the tree.
+        /// </summary>
+        /// <remarks>
+        ///  the localitem is enough for uSync to start a sync process it tells us
+        ///  the Id, Udi & Entity type of an item (and the name for nice UI)
+        /// </remarks>
+        public SyncLocalItem GetEntity(SyncTreeItem treeItem)
+        {
+            var entityType = GetEntityTypeFromTree(treeItem);
+            if (string.IsNullOrEmpty(entityType)) return null;
+
+            switch (entityType)
+            {
+                case VendrConstants.UdiEntityType.Store:
+                    return GetStoreItem(treeItem.Id);
+                default:
+                    return GetStoreSubItem(treeItem.Id, treeItem.QueryStrings["storeId"], entityType);
+            }
+
+        }
+
+        private SyncLocalItem GetStoreItem(string id)
+        {
+            // only showing the menu for the store 
+            var storeGuid = GetStoreGuid(id);
+            if (storeGuid == null) return null;
+
+            // the isVendrStore proved this was a guid.
+
+            var store = _vendrApi.GetStore(storeGuid.Value);
+            if (store == null) return null;
+
+            return new SyncLocalItem
+            {
+                EntityType = VendrConstants.UdiEntityType.Store,
+                Id = store.Id.ToString(),
+                Name = store.Name,
+                Udi = Udi.Create(VendrConstants.UdiEntityType.Store, store.Id)
+            };
+        }
+
+        private StoreReadOnly GetStoreById(string id)
+        {
+            var storeId = GetStoreGuid(id);
+            if (storeId == null) return null;
+            return _vendrApi.GetStore(storeId.Value);
+        }
+
+        /// <summary>
+        ///  a sub item of the store - we return the 'root' item this type - as we are going to sync it all.
+        /// </summary>
+        private SyncLocalItem GetStoreSubItem(string id, string storeId, string entityType)
+        {
+            var store = GetStoreById(storeId);
+
+            return new SyncLocalItem
+            {
+                EntityType = entityType,
+                Id = id,
+                Name = $"{store.Name} {entityType}",
+                Udi = Udi.Create(entityType, store.Id),
+            };
+        }
+
+        public IEnumerable<SyncItem> GetItems(SyncItem item)
+        {
+            // for the store just return ths store item,
+            // the depdency checker will do the rest.
+            if (item.Udi.EntityType == VendrConstants.UdiEntityType.Store)
+                return item.AsEnumerableOfOne();
+
+            // for other items the ID might be the store ID 
+            // which acts as a root Udi for that type in the store. 
+            if (item.Udi is GuidUdi guidUdi)
+            {
+                var store = _vendrApi.GetStore(guidUdi.Guid);
+                if (store == null) return item.AsEnumerableOfOne();
+
+                // if it was the store, get all the items of that type 
+
+                // there might be a more generic way of doing this ?
+                switch (item.Udi.EntityType)
+                {
+                    case VendrConstants.UdiEntityType.OrderStatus:
+                        return _vendrApi.GetOrderStatuses(store.Id)
+                            .Select(x => new SyncItem
+                            {
+                                Name = x.Name,
+                                Udi = Udi.Create(VendrConstants.UdiEntityType.OrderStatus, x.Id),
+                                Flags = item.Flags,
+                            });
+                            
+                }
+            }
+            return item.AsEnumerableOfOne();
+        }
+
+
+        
+
+
+        /// <summary>
+        ///  uSync Exporter - supply the info for it to open the picker. 
+        /// </summary>
+        public SyncEntityInfo GetSyncInfo(string entityType)
+        {
+            var x = entityType;
+            return null;
+        }
+
+        /// <summary>
+        ///  tells usync what type of sync this is (settings, content, files)
+        /// </summary>
+        public SyncTreeType GetTreeType(SyncTreeItem treeItem)
+        {
+            var entityType = GetEntityTypeFromTree(treeItem);
+            if (entityType != null) return SyncTreeType.Settings;
+
+            return SyncTreeType.None;
+        }
+
+        private Guid? GetStoreGuid(string id)
+        {
+            if (Guid.TryParse(id, out Guid storeGuid))
+                return storeGuid;
+
+            return null;
+        }
+
+
+
+        private string GetEntityTypeFromTree(SyncTreeItem item)
+        {
+            if (GetStoreGuid(item.Id) != null) return VendrConstants.UdiEntityType.Store;
+
+            var storeId = item.QueryStrings?["storeId"];
+            if (string.IsNullOrWhiteSpace(storeId)) return string.Empty;
+
+            var attempt = item.Id.TryConvertTo<int>();
+            if (!attempt.Success) return string.Empty;
+
+            var vendrNodeType = Vendr.Web.Constants.Trees.Settings.Ids.FirstOrDefault(x => x.Value == attempt.Result).Key;
+
+            if (_nodeToEntityMapping.ContainsKey(vendrNodeType))
+                return _nodeToEntityMapping[vendrNodeType];
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Vendr.uSync/Vendr.uSync.csproj
+++ b/src/Vendr.uSync/Vendr.uSync.csproj
@@ -51,11 +51,20 @@
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.Identity.Core.2.2.2\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\Testing\vendr-store\vendr-demo-store\packages\Microsoft.AspNet.SignalR.Client.2.4.1\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\Testing\vendr-store\vendr-demo-store\packages\Microsoft.AspNet.SignalR.Core.2.4.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\Testing\vendr-store\vendr-demo-store\packages\Microsoft.Owin.Security.2.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.3.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
@@ -130,9 +139,11 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -149,17 +160,25 @@
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
-    <Reference Include="uSync8.BackOffice, Version=8.8.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\uSync.BackOffice.Core.8.8.4\lib\net472\uSync8.BackOffice.dll</HintPath>
+    <Reference Include="uSync8.BackOffice, Version=8.10.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\uSync.BackOffice.Core.8.10.2\lib\net472\uSync8.BackOffice.dll</HintPath>
     </Reference>
-    <Reference Include="uSync8.Core, Version=8.8.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\uSync.Core.8.8.4\lib\net472\uSync8.Core.dll</HintPath>
+    <Reference Include="uSync8.Core, Version=8.10.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\uSync.Core.8.10.2\lib\net472\uSync8.Core.dll</HintPath>
     </Reference>
     <Reference Include="Vendr.Core, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Vendr.Core.1.8.0\lib\net472\Vendr.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Vendr.Core.Web, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\Testing\vendr-store\vendr-demo-store\packages\Vendr.Core.Web.1.8.0\lib\net472\Vendr.Core.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="Vendr.Web, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\Testing\vendr-store\vendr-demo-store\packages\Vendr.Web.1.8.0\lib\net472\Vendr.Web.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dependencies\VendrOrderStatusDependecyChecker.cs" />
+    <Compile Include="Dependencies\VendrStoreDependencyChecker.cs" />
     <Compile Include="Extensions\XElementExtensions.cs" />
     <Compile Include="Handlers\CountryHandler.cs" />
     <Compile Include="Handlers\CurrencyHandler.cs" />
@@ -187,6 +206,9 @@
     <Compile Include="Serializers\StoreSerializer.cs" />
     <Compile Include="Serializers\TaxClassSerializer.cs" />
     <Compile Include="Serializers\VendrSerializerBase.cs" />
+    <Compile Include="ServiceConnectors\StoreServiceConnector.cs" />
+    <Compile Include="ServiceConnectors\VendrBaseServiceConnector.cs" />
+    <Compile Include="SyncManagers\OrderSyncManager.cs" />
     <Compile Include="SyncModels\SyncTaxRateModel.cs" />
     <Compile Include="SyncModels\SyncAllowedCountryRegionModel.cs" />
     <Compile Include="SyncModels\SyncServicePriceModel.cs" />
@@ -197,6 +219,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="Config\uSync8.config" />
     <None Include="Web\UI\App_Plugins\Vendr.uSync\config\uSync8.config.install.xdt" />
     <None Include="packages.config" />
     <None Include="Web\UI\App_Plugins\Vendr.uSync\package.manifest" />
@@ -204,6 +227,7 @@
   <ItemGroup>
     <Content Include="Web\UI\App_Plugins\Vendr.uSync\lang\en-us.xml" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Vendr.uSync/VendrConstants.cs
+++ b/src/Vendr.uSync/VendrConstants.cs
@@ -56,5 +56,37 @@
             public const int PaymentMethod = VENDR_RESERVED_LOWER + 21; // requires store, countries, currencies
             public const int ShippingMethod = VENDR_RESERVED_LOWER + 22;// requires store, countries, currencies
         }
+
+        public static class UdiEntityType
+        {
+            public const string Store = "vendr-store";
+
+            public const string Country = "vendr-country";
+
+            public const string Region = "vendr-region";
+
+            public const string Currency = "vendr-currency";
+
+            public const string OrderStatus = "vendr-order-status";
+
+            public const string ShippingMethod = "vendr-shipping-method";
+
+            public const string PaymentMethod = "vendr-payment-method";
+
+            public const string TaxClass = "vendr-tax-class";
+
+            public const string EmailTemplate = "vendr-email-template";
+
+            public const string PrintTemplate = "vendr-print-template";
+
+            public const string ExportTemplate = "vendr-export-template";
+
+            public const string Discount = "vendr-discount";
+
+            public const string GiftCard = "vendr-gift-card";
+
+            public const string ProductAttribute = "vendr-product-attribute";
+        }
     }
 }
+

--- a/src/Vendr.uSync/app.config
+++ b/src/Vendr.uSync/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Vendr.uSync/packages.config
+++ b/src/Vendr.uSync/packages.config
@@ -5,9 +5,12 @@
   <package id="LightInject.Annotation" version="1.1.0" targetFramework="net472" />
   <package id="LightInject.Web" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.SignalR.Client" version="2.4.1" targetFramework="net472" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.4.0" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net472" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net472" />
   <package id="MiniProfiler" version="4.0.138" targetFramework="net472" />
   <package id="MiniProfiler.Shared" version="4.0.138" targetFramework="net472" />
@@ -31,7 +34,9 @@
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
   <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
-  <package id="uSync.BackOffice.Core" version="8.8.4" targetFramework="net472" />
-  <package id="uSync.Core" version="8.8.4" targetFramework="net472" />
+  <package id="uSync.BackOffice.Core" version="8.10.2" targetFramework="net472" />
+  <package id="uSync.Core" version="8.10.2" targetFramework="net472" />
   <package id="Vendr.Core" version="1.8.0" targetFramework="net472" />
+  <package id="Vendr.Core.Web" version="1.8.0" targetFramework="net472" />
+  <package id="Vendr.Web" version="1.8.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Work in progress (still draft). 

This adds support for SyncItemManager which was introduced in uSync 8.10.x and allows us to add Push/Pull context menus when uSync.Complete is installed. 

at the moment this is against the v1.8 version of Vendr - it might be better doing this against v2.x ?