### PR TITLE
V3/feature/payment settings

### DIFF
--- a/src/Vendr.uSync/Serializers/PaymentMethodSeralizer.cs
+++ b/src/Vendr.uSync/Serializers/PaymentMethodSeralizer.cs
@@ -137,6 +137,11 @@ namespace Vendr.uSync.Serializers
                 foreach (var setting in root.Elements("Setting"))
                 {
                     var key = setting.Element("Key").ValueOrDefault(string.Empty);
+
+                    // don't do anything with settings that are in the ignore list. 
+                    if (StringExtensions.InvariantContains(_settingsAccessor.Settings.PaymentMethods.IgnoreSettings, key))
+                        continue;
+
                     if (!string.IsNullOrWhiteSpace(key))
                     {
                         var value = setting.Element("Value").ValueOrDefault(string.Empty);


### PR DESCRIPTION
Adds check for the "IgnoreSettings" value on Deserialize -  #15 

this just covers the situations where the values might have been exported on one site, which doesn't have the `IgnoreSettings` and we then don't want to import them onto the other end. 