### PR TITLE
Product Attributes Syncing

### DIFF
--- a/src/Vendr.uSync/Dependencies/VendrProductAttributeDependencyChecker.cs
+++ b/src/Vendr.uSync/Dependencies/VendrProductAttributeDependencyChecker.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Vendr.Core.Models;
+using uSync.Core.Dependency;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+namespace Vendr.uSync.Dependencies
+{
+    public class VendrProductAttributeDependencyChecker :
+        ISyncDependencyChecker<ProductAttributeReadOnly>
+    {
+        public UmbracoObjectTypes ObjectType => UmbracoObjectTypes.Unknown;
+
+        public IEnumerable<uSyncDependency> GetDependencies(ProductAttributeReadOnly item, DependencyFlags flags)
+            => new uSyncDependency
+            {
+                Name = item.Name,
+                Order = VendrConstants.Priorites.ProductAttributes,
+                Udi = Udi.Create(VendrConstants.UdiEntityType.ProductAttribute, item.Id)
+            }.AsEnumerableOfOne();
+    }
+}

--- a/src/Vendr.uSync/Extensions/XElementExtensions.cs
+++ b/src/Vendr.uSync/Extensions/XElementExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 using uSync.Core;
 
@@ -32,5 +33,36 @@ namespace Vendr.uSync.Extensions
 
         public static void AddStoreId(this XElement node, Guid storeId)
             => node.Add(new XElement("StoreId", storeId));
+
+
+        public static XElement AddDictionary(this XElement node, IReadOnlyDictionary<string, string> dictionary)
+        {
+            if (dictionary != null && dictionary.Count > 0)
+            {
+                foreach(var item in dictionary)
+                {
+                    node.Add(new XElement("Value", new XAttribute("Key", item.Key), item.Value));
+                }
+            }
+
+            return node;
+        }
+
+        public static IDictionary<string, string> GetDictionary(this XElement node)
+        {
+            var dictionary = new Dictionary<string, string>();
+            if (node == null || !node.HasElements) return dictionary;
+
+            foreach (var itemNode in node.Elements("Value"))
+            {
+                var key = itemNode.Attribute("Key").ValueOrDefault(string.Empty);
+                var value = itemNode.ValueOrDefault(string.Empty);
+
+                if (!string.IsNullOrEmpty(key))
+                    dictionary.Add(key, value);
+            }
+
+            return dictionary;
+        }
     }
 }

--- a/src/Vendr.uSync/Handlers/ProductAttributesHandler.cs
+++ b/src/Vendr.uSync/Handlers/ProductAttributesHandler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.BackOffice.SyncHandlers;
+using uSync.Core;
+
+using Vendr.Common.Events;
+using Vendr.Core.Api;
+using Vendr.Core.Events.Notification;
+using Vendr.Core.Models;
+
+namespace Vendr.uSync.Handlers;
+
+[SyncHandler("vendrProductAttributesHandler", "Product Attributes", "Vendr\\ProductAttrivutes", VendrConstants.Priorites.ProductAttributes,
+       Icon = "icon-multiple-credit-cards", EntityType = VendrConstants.UdiEntityType.ProductAttribute)]
+public class ProductAttributesHandler : VendrSyncHandlerBase<ProductAttributeReadOnly>, ISyncVendrHandler
+    , IEventHandlerFor<ProductAttributeSavedNotification>
+    , IEventHandlerFor<ProductAttributeDeletedNotification>
+
+{
+    public ProductAttributesHandler(
+        IVendrApi vendrApi,
+        ILogger<VendrSyncHandlerBase<ProductAttributeReadOnly>> logger,
+        AppCaches appCaches,
+        IShortStringHelper shortStringHelper,
+        SyncFileService syncFileService,
+        uSyncEventService mutexService,
+        uSyncConfigService uSyncConfig,
+        ISyncItemFactory itemFactory) 
+        : base(vendrApi, logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+    { }
+
+    protected override IEnumerable<ProductAttributeReadOnly> GetByStore(Guid storeId)
+        => _vendrApi.GetProductAttributes(storeId);
+
+    protected override void DeleteViaService(ProductAttributeReadOnly item)
+        => _vendrApi.DeleteProductAttribute(item.Id);
+
+    protected override ProductAttributeReadOnly GetFromService(Guid key)
+        => _vendrApi.GetProductAttribute(key);
+
+    protected override string GetItemName(ProductAttributeReadOnly item)
+        => item.Name;
+
+    public void Handle(ProductAttributeSavedNotification notification)
+        => VendrItemSaved(notification.ProductAttribute);
+
+    public void Handle(ProductAttributeDeletedNotification notification)
+        => VendrItemDeleted(notification.ProductAttribute);
+}

--- a/src/Vendr.uSync/Serializers/ProductAttributesSerializer.cs
+++ b/src/Vendr.uSync/Serializers/ProductAttributesSerializer.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+using Microsoft.Extensions.Logging;
+
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+
+using Vendr.Common;
+using Vendr.Core.Api;
+using Vendr.Core.Models;
+using Vendr.Extensions;
+using Vendr.uSync.Configuration;
+using Vendr.uSync.Extensions;
+
+namespace Vendr.uSync.Serializers;
+
+[SyncSerializer("43AD88B3-AB60-438E-A8E8-30223CFD739C", "Product Attribute Serializer",
+    VendrConstants.Serialization.ProductAttributes)]
+public class ProductAttributesSerializer : VendrSerializerBase<ProductAttributeReadOnly>, ISyncSerializer<ProductAttributeReadOnly>
+{
+    public ProductAttributesSerializer(
+        IVendrApi vendrApi,
+        VendrSyncSettingsAccessor settingsAccessor,
+        IUnitOfWorkProvider uowProvider,
+        ILogger<VendrSerializerBase<ProductAttributeReadOnly>> logger) 
+        : base(vendrApi, settingsAccessor, uowProvider, logger)
+    { }
+
+    public override string GetItemAlias(ProductAttributeReadOnly item) 
+        => item.Alias;
+
+    protected override SyncAttempt<XElement> SerializeCore(ProductAttributeReadOnly item, SyncSerializerOptions options)
+    {
+        var node = InitializeBaseNode(item, ItemAlias(item));
+
+
+        node.Add(new XElement(nameof(item.Name), 
+            new XAttribute("Default", item.Name.GetDefaultValue()))
+            .AddDictionary(item.Name.GetTranslatedValues()));
+
+        node.Add(new XElement(nameof(item.SortOrder), item.SortOrder));
+        node.AddStoreId(item.StoreId);
+
+        node.Add(SerializeAttributeValues(item.Values));
+
+        return SyncAttemptSucceedIf(node != null, item.Name, node, ChangeType.Export);
+    }
+
+    private XElement SerializeAttributeValues(IReadOnlyCollection<ProductAttributeValueReadOnly> values)
+    {
+        var valuesNode = new XElement("Values");
+        if (values == null) return valuesNode;
+
+        foreach(var value in values)
+        {
+            var valueNode = new XElement("Value");
+            valueNode.Add(new XElement(nameof(value.Alias), value.Alias));
+
+            valueNode.Add(new XElement(nameof(value.Name),
+                   new XAttribute("Default", value.Name.GetDefaultValue()))
+                   .AddDictionary(value.Name.GetTranslatedValues()));
+
+            valuesNode.Add(valueNode);
+        }
+
+        return valuesNode;
+    }
+
+    public override bool IsValid(XElement node)
+        => base.IsValid(node)
+        && node.GetStoreId() != Guid.Empty;
+
+    protected override SyncAttempt<ProductAttributeReadOnly> DeserializeCore(XElement node, SyncSerializerOptions options)
+    {
+        var readonlyitem = FindItem(node);
+
+        var alias = node.GetAlias();
+        var id = node.GetKey();
+        var defaultName = node.Element(nameof(readonlyitem.Name)).Attribute("Default").ValueOrDefault(string.Empty);
+        var translatedNames = node.Element(nameof(readonlyitem.Name)).GetDictionary();
+        var storeId = node.GetStoreId();
+
+        return _uowProvider.Execute(uow =>
+        {
+            ProductAttribute item;
+
+            if (readonlyitem == null)
+            {
+                item = ProductAttribute.Create(uow, storeId, alias, defaultName);
+            }
+            else
+            {
+                item = readonlyitem.AsWritable(uow);
+            }
+
+            item.SetAlias(alias)
+                .SetName(new TranslatedValue<string>(defaultName, translatedNames))
+                .SetSortOrder(node.Element(nameof(item.SortOrder)).ValueOrDefault(item.SortOrder));
+
+            DeserializeAttributeValues(node, item);
+
+            return uow.Complete(SyncAttemptSucceed(defaultName, item.AsReadOnly(), ChangeType.Import));
+        });
+    }
+
+    private void DeserializeAttributeValues(XElement node, ProductAttribute item)
+    {
+        var attributeValues = new Dictionary<string, TranslatedValue<string>>();
+
+        var valuesNode = node.Element("Values");
+        if (valuesNode != null && valuesNode.HasElements)
+        {
+            foreach(var valueNode in valuesNode.Elements("Value"))
+            {
+                var alias = valueNode.Element("Alias").ValueOrDefault(string.Empty);
+                var ProductAttributeId = valueNode.Element("ProductAttributeId").ValueOrDefault(Guid.Empty);
+
+                var defaultName = valueNode.Element("Name").Attribute("Default").ValueOrDefault(string.Empty);
+                var translatedNames = valueNode.Element("Name").GetDictionary();
+
+                if (!string.IsNullOrWhiteSpace(alias))
+                {
+                    attributeValues.Add(alias, new TranslatedValue<string>(defaultName, translatedNames));
+                }
+            }
+        }
+
+        item.SetValues(attributeValues);
+    }
+
+
+    public override void DoDeleteItem(ProductAttributeReadOnly item)
+       => _vendrApi.DeleteProductAttribute(item.Id);
+
+    public override ProductAttributeReadOnly DoFindItem(Guid key)
+        => _vendrApi.GetProductAttribute(key);
+
+    public override void DoSaveItem(ProductAttributeReadOnly item)
+    {
+        _uowProvider.Execute(uow =>
+        {
+            var entity = item.AsWritable(uow);
+            _vendrApi.SaveProductAttribute(entity);
+            uow.Complete();
+        });
+    }
+
+}

--- a/src/Vendr.uSync/SyncManagers/ProductAttributeSyncManager.cs
+++ b/src/Vendr.uSync/SyncManagers/ProductAttributeSyncManager.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+using Umbraco.Extensions;
+
+using uSync.Core.Sync;
+
+using Vendr.Core.Api;
+using Vendr.Core.Models;
+
+using static Vendr.Umbraco.Constants.Trees.Stores;
+
+namespace Vendr.uSync.SyncManagers;
+public class ProductAttributeSyncManager : ISyncItemManager
+{
+    private readonly IVendrApi _vendrApi;
+
+    public ProductAttributeSyncManager(IVendrApi vendrApi)
+    {
+        _vendrApi = vendrApi;
+    }
+
+
+    /// <summary>
+    ///  mappings helps us get to and from a UDI to an Vendr NodeType
+    /// </summary>
+    private readonly Dictionary<string, string> _mappings = new Dictionary<string, string>
+    {
+        { nameof(NodeType.ProductAttributes), VendrConstants.UdiEntityType.ProductAttribute }
+    };
+
+
+    /// <summary>
+    ///  what entity types do we support ? 
+    /// </summary>
+    public string[] EntityTypes => _mappings.Values.ToArray();
+
+    /// <summary>
+    ///  what Umbraco tree do the items live on
+    /// </summary>
+    public string[] Trees => new[] { Vendr.Umbraco.Constants.Trees.Stores.Alias };
+
+    /// <summary>
+    ///  return an entity based on the info we get from the tree.
+    /// </summary>
+    public SyncLocalItem GetEntity(SyncTreeItem treeItem)
+    {
+        var entityType = GetEntityTypeFromTree(treeItem);
+        if (string.IsNullOrEmpty(entityType)) return null;
+        
+        return GetStoreSubItem(treeItem.Id, treeItem.QueryStrings["storeId"], entityType); 
+    }
+
+    private SyncLocalItem GetStoreSubItem(string id, string storeId, string entityType)
+    {
+        var store = GetStoreById(storeId);
+
+        return new SyncLocalItem
+        {
+            EntityType = entityType,
+            Id = id,
+            Name = $"{store.Name} {entityType}",
+            Udi = Udi.Create(entityType, store.Id)
+        };
+    }
+
+    /// <summary>
+    ///  publisher uses this as the starting point, the root items we will sync.
+    /// </summary>
+    public IEnumerable<SyncItem> GetItems(SyncItem item)
+    {
+        if (item.Udi is GuidUdi udi)
+        {
+            var attributes = _vendrApi.GetProductAttributes(udi.Guid);
+
+            return attributes.Select(x => new SyncItem
+            {
+                Name = x.Name,
+                Udi = Udi.Create(VendrConstants.UdiEntityType.ProductAttribute, x.Id),
+                Flags = item.Flags
+            });
+        }
+
+        return item.AsEnumerableOfOne();
+        
+    }
+
+    /// <summary>
+    ///  uSync.Exporter - if you return the entity info, then exporter 
+    ///  can use this to open a picker on its dashboard.
+    /// </summary>
+    /// <remarks>
+    ///  if this is null, then the item doesn't appear pickable in uSync.Exporter
+    /// </remarks>
+    public SyncEntityInfo GetSyncInfo(string entityType)
+        => null;
+
+    /// <summary>
+    ///  tells uSync.Publisher what type of 'sync' we are doing. 
+    /// </summary>
+    /// <remarks>
+    ///  in general there are content, settings and file syncs, and this controls
+    ///  what options a user sees, almost always you will want settings. 
+    /// </remarks>
+    public SyncTreeType GetTreeType(SyncTreeItem treeItem)
+        => SyncTreeType.Settings;
+
+
+    /// <summary>
+    ///  helper function to get the UdiEntityType based on the values 
+    ///  in the Umbraco tree query. 
+    /// </summary>
+    private string GetEntityTypeFromTree(SyncTreeItem item)
+    {
+        var nodeType = item.QueryStrings?["nodeType"];
+        if (string.IsNullOrEmpty(nodeType)) return null;
+
+        if (_mappings.ContainsKey(nodeType))
+            return _mappings[nodeType];
+
+        return null;
+
+    }
+
+    private Guid? GetStoreGuid(string id)
+    {
+        if (Guid.TryParse(id, out Guid storeGuid))
+            return storeGuid;
+
+        return null;
+    }
+
+    private StoreReadOnly GetStoreById(string id)
+    {
+        var storeId = GetStoreGuid(id);
+        if (storeId == null) return null;
+        return _vendrApi.GetStore(storeId.Value);
+    }
+}

--- a/src/Vendr.uSync/VendrConstants.cs
+++ b/src/Vendr.uSync/VendrConstants.cs
@@ -20,6 +20,8 @@
 
             public const string PaymentMethod = "PaymentMethod";
             public const string ShippingMethod = "ShippingMethod";
+
+            public const string ProductAttributes = "ProductAttributes";
         }
 
         internal static class Priorites
@@ -55,6 +57,8 @@
 
             public const int PaymentMethod = VENDR_RESERVED_LOWER + 21; // requires store, countries, currencies
             public const int ShippingMethod = VENDR_RESERVED_LOWER + 22;// requires store, countries, currencies
+
+            public const int ProductAttributes = VENDR_RESERVED_LOWER + 23; // requires store
         }
 
         public static class UdiEntityType

--- a/src/Vendr.uSync/VendrSyncComposer.cs
+++ b/src/Vendr.uSync/VendrSyncComposer.cs
@@ -38,7 +38,10 @@ namespace Vendr.uSync
             UdiParserServiceConnectors.RegisterServiceConnector<ExportTemplateServiceConnector>();
             UdiParserServiceConnectors.RegisterServiceConnector<PrintTemplateServiceConnector>();
 
-            // QUESTION: Can the above be replaced now with UdiParser.RegisterUdiType(string entityType, UdiType udiType)?
+            // QUESTION: Can the above be replaced now with UdiParser.RegisterUdiTye(string entityType, UdiType udiType)?
+
+            // ANSWER: It does appear to work, we will change this in another PR 
+            UdiParser.RegisterUdiType(VendrConstants.UdiEntityType.ProductAttribute, UdiType.GuidUdi);
         }
     }
 }


### PR DESCRIPTION
Adds syncing for product attributes #4 

- ProductAttributeHandler,
- ProductAttributesSerializer

Also adds right click push/pull features for uSync Complete

- ProductAttributeSyncManager (tells uSync that it can push these via a menu)
- VendrProductAttributeDependencyChecker (tells uSync what dependencies exist for the item when pushing it (just itself)
